### PR TITLE
Feature: Trigger README update when repo is rebuilt

### DIFF
--- a/.github/workflows/dynamic-readme.yml
+++ b/.github/workflows/dynamic-readme.yml
@@ -45,5 +45,5 @@ jobs:
           git config --global user.name "Pi4J Bot"
           git status
           git add README.md
-          git commit -am "[AUTO] rebuild dynamic readme"
+          git commit -am "[AUTO] rebuild dynamic readme" || true
           git push

--- a/.github/workflows/rebuild-repo.yml
+++ b/.github/workflows/rebuild-repo.yml
@@ -36,3 +36,14 @@ jobs:
           git add dists/.
           git commit -am "[AUTO] rebuild distribution respository indices"
           git push
+      - name: Trigger dynamic README update of Pi4J/download
+        env:
+          GITHUB_PAT: ${{ secrets.PI4J_BOT_GITHUB_PAT }}
+        run: >-
+          curl
+          --silent --show-error --fail --fail
+          -X POST
+          -H "Accept: application/vnd.github.v3+json"
+          -H "Authorization: Token ${GITHUB_PAT}"
+          https://api.github.com/repos/pi4j/download/actions/workflows/dynamic-readme.yml/dispatches
+          -d '{"ref":"refs/heads/main"}'


### PR DESCRIPTION
This PR finalizes #1 and #2 by adding the workflow-dispatch API trigger to the `rebuild-repo` task. While we could directly trigger inside this repository, doing so /after/ the `rebuild-repo` task seems like the safer option as otherwise there might be commit conflicts.

It also adds a small safe-guard to the `git commit [...]` command to not fail when the README is exactly the same.